### PR TITLE
ENH: allow pickling SumEncoder

### DIFF
--- a/sleepmind/preprocessing/sum_encoding.py
+++ b/sleepmind/preprocessing/sum_encoding.py
@@ -1,4 +1,4 @@
-from collections import defaultdict, Counter
+from collections import defaultdict
 
 import numpy as np
 import pandas as pd
@@ -30,14 +30,14 @@ class SumEncoder(BaseTransformer):
             X = X.reshape(-1, n_cols)
 
         self.col_names = list(range(n_cols))
-        store = defaultdict(lambda: defaultdict(list))
+        store = defaultdict(get_defaultdict_of_list)
         for row, label in zip(X, y):
             # if not n_cols > 1:
                 # row = [row]
             for col, level in enumerate(row):
                 store[col][level].append(label)
 
-        self.encoding = defaultdict(lambda: defaultdict(list))
+        self.encoding = defaultdict(get_defaultdict_of_list)
         for col in self.col_names:
             for level, labels in store[col].items():
                 numerator = np.nanmean(labels)
@@ -73,3 +73,7 @@ class SumEncoder(BaseTransformer):
                 new_row = [self.encoding[0].get(X[row], 1)]
             values.append(new_row)
         return np.array(values).reshape(-1, n_cols)
+
+
+def get_defaultdict_of_list():
+    return defaultdict(list)

--- a/tests/test_sum_encodig.py
+++ b/tests/test_sum_encodig.py
@@ -1,3 +1,6 @@
+import pickle
+from io import BytesIO
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -74,5 +77,29 @@ def test_sum_encoding_pipeline():
     assert_array_almost_equal(
         result,
         np.array([[0.75], [0.75], [1.3333], [1.3333], [1.3333]]),
+        decimal=4,
+    )
+
+
+def test_sum_encoding_pickle():
+    # given
+    train = pd.DataFrame(data={
+        'animal': ['dog', 'dog', 'cat', 'cat', 'cat'],
+        'label': [1, 0, 1, 1, 0],
+    })
+    transformer = SumEncoder().fit(X=train.animal, y=train.label)
+
+    # when
+    pickle_file = BytesIO(pickle.dumps(obj=transformer))
+    unpickled_transformer = pickle.load(file=pickle_file)
+    test = pd.DataFrame(data={
+        'animal': ['dog', 'cat', 'elephant']
+    })
+    result = unpickled_transformer.transform(X=test.animal)
+
+    # then
+    assert_array_almost_equal(
+        result,
+        np.array([[0.75], [1.3333], [1]]),
         decimal=4,
     )


### PR DESCRIPTION
This PR introduces a minor change in the transformer `SumEncoder` so that it can be pickled. The limitation arose from the use of `lambda` functions, which cannot be pickled.